### PR TITLE
feat: add release-please for apps

### DIFF
--- a/workflow-templates/release-please-app.properties.json
+++ b/workflow-templates/release-please-app.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Release new App version Workflow",
+  "description": "Manage app releases and versioning with automatic changelogs.",
+  "iconName": "graasp-logo",
+  "categories": ["Automation", "Deployment", "Continuous integration"],
+  "filePatterns": ["package.json$"]
+}

--- a/workflow-templates/release-please-app.yml
+++ b/workflow-templates/release-please-app.yml
@@ -1,0 +1,49 @@
+# Automate releases of new app versions
+name: release-please
+
+on:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          # TODO: replace this with your app name
+          package-name: USE_YOUR_APP_NAME
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"test","section":"Tests","hidden":false}]'
+
+      - uses: actions/checkout@v3
+
+      # creates minor and major tags that follow the latest release
+      - name: Tag major and minor versions
+        uses: jacobsvante/tag-major-minor-action@v0.1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          major: ${{ steps.release.outputs.major }}
+          minor: ${{ steps.release.outputs.minor }}
+
+      # put created tag in an env variable to be sent to the dispatch
+      - name: Set tag
+        if: ${{ steps.release.outputs.release_created }}
+        id: set-tag
+        run: |
+          REPOSITORY=$(echo '${{ github.repository }}')
+          TAG=$(echo '${{ steps.release.outputs.tag_name }}')
+          JSON=$(jq -c --null-input --arg repository "$REPOSITORY" --arg tag "$TAG" '{"repository": $repository, "tag": $tag}')
+          echo "json=$JSON" >> $GITHUB_OUTPUT
+
+      # Trigger an 'on: repository_dispatch' workflow to run in graasp-deploy repository
+      - name: Push tag to Graasp Deploy (Staging)
+        if: ${{ steps.release.outputs.release_created }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: graasp/graasp-deploy
+          event-type: update-staging-version
+          client-payload: ${{steps.set-tag.outputs.json}}


### PR DESCRIPTION
This PR adds a release-please workflow to create new app versions.
This workflow is intended to be used as a replacement for the "Push new tag to graasp deploy" workflow using the `standard-version` package.

closes #8 