### PR TITLE
fix: add organisation profile page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ You are here in our Github Organisation. This is where we develop the Graasp pla
 
 If you know programming and would like to help us by contributing some code please look at the open issues and mention the `@graasp/dev` to let us know you would like to tackle this issue. We primarily use Typescript and React.js.
 
-If you do not know programming you can still help us by **reporting bugs** and **proposing features** in our [Graasp Feedback Repo](https://github.com/graasp-feedback). We also are eager to hear about your experience on the platform. Do not hesitate to drop us an email at admin [at] graasp [dot] org.
+If you do not know programming you can still help us by **reporting bugs** and **proposing features** in our [Graasp Feedback Repo](https://github.com/graasp-feedback). We also are eager to hear about your experience on the platform. Do not hesitate to drop us an email at admin@graasp.org.
 
 ## Documentation
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,17 @@
+# Graasp
+
+Graasp is an online education platform. We like to call it a "Learning experience platform". We are developing an open platform for educators and students, allowing them to create, consume, share and analyze in a single place. We believe that high quality education material deserves to be shared and accessible to everyone. If you are interested in what we have to offer please visit our website [graasp.org](https://graasp.org).
+
+You are here in our Github Organisation. This is where we develop the Graasp platform as an open source project.
+
+If you know programming and would like to help us by contributing some code please look at the open issues and mention the `@graasp/dev` to let us know you would like to tackle this issue. We primarily use Typescript and React.js.
+
+If you do not know programming you can still help us by **reporting bugs** and **proposing features** in our [Graasp Feedback Repo](https://github.com/graasp-feedback). We also are eager to hear about your experience on the platform. Do not hesitate to drop us an email at admin [at] graasp [dot] org.
+
+## Documentation
+
+We have [a documentation website](https://graasp.github.io/docs) where we publish content for developers (high level documentation, start-up guides, troubleshooting etc). This site s also where we publish [news and updates](https://graasp.github.io/docs/blog) in the form of blog posts. If you want to keep up to date, you can add our [RSS feed](https://graasp.github.io/docs/blog/rss.xml).
+
+## Developing with us
+
+To get started developing with us head to [the development start-up guide](https://graasp.github.io/docs/developer/intro) for some information on how to setup your development environment and run the project locally.

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@ If you do not know programming you can still help us by **reporting bugs** and *
 
 ## Documentation
 
-We have [a documentation website](https://graasp.github.io/docs) where we publish content for developers (high level documentation, start-up guides, troubleshooting etc). This site s also where we publish [news and updates](https://graasp.github.io/docs/blog) in the form of blog posts. If you want to keep up to date, you can add our [RSS feed](https://graasp.github.io/docs/blog/rss.xml).
+We have [a documentation website](https://graasp.github.io/docs) where we publish content for developers (high level documentation, start-up guides, troubleshooting etc). This site is also where we publish [news and updates](https://graasp.github.io/docs/blog) in the form of blog posts. If you want to keep up to date, you can add our [RSS feed](https://graasp.github.io/docs/blog/rss.xml).
 
 ## Developing with us
 


### PR DESCRIPTION
In this PR I add a readme file that will be displayed in the organisation page of graasp in github. Let me know if I should add other things. 